### PR TITLE
Fix Package target in build script

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -87,11 +87,9 @@ Target.create "Package" (fun _ ->
     |> Seq.iter (fun s ->
         let dir = Path.GetDirectoryName s
         DotNet.pack (fun a ->
-            let c =
-                { a.Common with
-                    CustomParams = Some "-c Release"
-                    WorkingDirectory = dir }
-            { a with Common = c }
+            { a with
+                Configuration = DotNet.BuildConfiguration.Release
+                Common = { a.Common with WorkingDirectory = dir } }
         ) s
     )
 )


### PR DESCRIPTION
When I attempted to run `build.cmd Package` locally, the build failed on the `Package` target. This PR resolves that problem for me.