### PR TITLE
Fix ofPromise signature

### DIFF
--- a/src/cmd.fs
+++ b/src/cmd.fs
@@ -93,14 +93,14 @@ module Cmd =
 
 #if FABLE_COMPILER
     /// Command to call `promise` block and map the results
-    let ofPromise (task: 'a -> Fable.Core.JS.Promise<_>)
+    let ofPromise (task: 'a -> Fable.Core.JS.Promise<'b>)
                   (arg:'a)
-                  (ofSuccess: _ -> 'msg)
-                  (ofError: _ -> 'msg) : Cmd<'msg> =
+                  (ofSuccess: 'b -> 'msg)
+                  (ofError: exn -> 'msg) : Cmd<'msg> =
         let bind dispatch =
             (task arg)
                 .``then``(ofSuccess >> dispatch)
-                .catch(ofError >> dispatch)
+                .catch((unbox ofError) >> dispatch)
                 |> ignore
         [bind]
 #else


### PR DESCRIPTION
Sorry, when I changed the body of `ofPromise` I didn't notice the `onError` argument was inferred now to be `obj->unit`. I've fixed to prevent compilation errors when updating the library.