### PR TITLE
Update broken link to elm-tutorial.org 

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
 <p><code>-ish</code> <br />
 a suffix used to convey the sense of “having some characteristics of”</p>
 </blockquote>
-<p>Elmish implements core abstractions that can be used to build Fable applications following the <a href="http://www.elm-tutorial.org/en/02-elm-arch/01-introduction.html">“model view update”</a> style of architecture, as made famous by Elm.</p>
+<p>Elmish implements core abstractions that can be used to build Fable applications following the <a href="https://guide.elm-lang.org/architecture/">“model view update”</a> style of architecture, as made famous by Elm.</p>
 <p>The goal of the architecture is to provide a solid UI-independent core to build the rest of the functionality around.
 Elm architecture operates using the following concepts, as they translate to Elmish:</p>
 <ul>


### PR DESCRIPTION
Updating the link to a more up to date overview of the architecture. The domain for elm-tutorial.org is up for sale and the creator/maintainer have indicated that there is not current plans of updating the tutorial sporto/elm-tutorial#205.