### PR TITLE
Fix model access race condition

### DIFF
--- a/src/program.fs
+++ b/src/program.fs
@@ -143,8 +143,8 @@ module Program =
                     try
                         let (model',cmd') = program.update msg state
                         program.setState model' syncDispatch
-                        cmd' |> Cmd.exec syncDispatch
                         state <- model'
+                        cmd' |> Cmd.exec syncDispatch
                     with ex ->
                         program.onError (sprintf "Unable to process the message: %A" msg, ex)
                     nextMsg <- rb.Pop()


### PR DESCRIPTION
Hello there.

I ran into an issue while using Elmish 3.0.3 in anger. When I added some logging to my `update` function I was amazed and flabbergasted when I observed that `update` was being invoked with the same `model` twice. This could not be. I checked my code. I was correctly transforming the `model` (decreasing a list in there). Yet, the same list whose head I had just chopped off was back again. And then the application would continue and 1 or 2 `update` invocations later, the list would start indeed decreasing as I expected.. Non sense.

In my scenario, one of the `update` invocations returns a `Cmd.batch` with 5 `Cmd.OfAsync.either` commands in there. This triggered me.

After staring at `Elmish.Program.runWith` function and then recursively staring at it again, I came up with an hypothesis that there is a "closure leakage/race condition" (sorry for my poor terminology), and that `cmd' |> Cmd.exec syncDispatch` could re-enter the closure taken by `let rec dispatch`, which includes the current (old!) state of `let mutable state`.

To challenge my hypothesis I created this Linqpad script:

```fsharp
type Msg =
    | Success
    | Failure of exn

let init () = 
    0, Cmd.ofMsg <| Success

let update msg model =
    let model = model + 1
    
    model, [0..5] |> List.map(fun i -> Cmd.OfAsync.either (fun (arg:int) -> Task.Delay(arg) |> Async.AwaitTask) (model + i) (fun _ -> Success) Failure) |> Cmd.batch
    
let noView _ _ = 
    ignore
    
let program =
    Program.mkProgram init update noView
    |> Program.withConsoleTrace
    |> Program.run
```

This is the dumbest program ever, but notice that it returns 5 `Cmd.OfAsync.either` commands, with a `|> Cmd.batch` and also notice that it will always increase the model **monotonically**.

If I run this code using the Elmish 3.0.3 package from nuget, I get the following output:
```
Initial state:: 0
New message:: Success
Updated state:: 1
New message:: Success
Updated state:: 2
New message:: Success
Updated state:: 3
(.... truncated ....)
Updated state:: 87
New message:: Success
Updated state:: 88
New message:: Success
New message:: Success
New message:: Success
Updated state:: 89
Updated state:: 89
Updated state:: 89
New message:: Success
New message:: Success
Updated state:: 90
Updated state:: 90
New message:: Success
Updated state:: 90
New message:: Success
Updated state:: 91
New message:: Success
New message:: Success
Updated state:: 91
New message:: Success
Updated state:: 91
Updated state:: 92
New message:: Success
New message:: Success
New message:: Success
Updated state:: 92
Updated state:: 93
Updated state:: 92
New message:: Success
New message:: Success
Updated state:: 93
Updated state:: 94
```

Notice that this reproduces what I was observing in my own code base: even though the `update` function monotonically increases the model by one, you can observe multiple invocations of it with the same value. 😖

I have forked this repository and applied the fix that I propose here, locally. I have used your build script to generate a local nuget package. I have executed the exact same code using that locally build package and I have run the application up to model value of 10000 and I can observe that the increase in now monotonic as expected.

Cheers and thank you for the Elmish package! ❤